### PR TITLE
Add test for permissions check for security and analysis edits

### DIFF
--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -252,7 +252,7 @@ func editRun(ctx context.Context, opts *EditOptions) error {
 		}
 	}
 
-	if hasSecurityEdits(opts.Edits) {
+	if opts.Edits.SecurityAndAnalysis != nil {
 		apiClient := api.NewClientFromHTTP(opts.HTTPClient)
 		repo, err := api.FetchRepository(apiClient, opts.Repository, []string{"viewerCanAdminister"})
 		if err != nil {


### PR DESCRIPTION
## Changes

- Change permissions check trigger to look for non-nil `opts.Edits.SecurityAndAnalysis` struct
- Add mock for `ViewerCanAdminister` repo permissions
- Add test for when a viewer does not have permissions to edit a repo's security and analysis features

## Explanation

1. In the tests, we weren't actually executing the code inside the permissions check block because we were setting `opts.Edits.SecurityAndAnalysis` in the test setup, but `hasSecurityEdits()` checks for `opts.Edits.enableAdvancedSecurity`, `opts.Edits.enableSecretScanning`, and `opts.Edits.enableSecretScanningPushProtection`. Updating the conditional on line 255 to `opts.Edits.SecurityAndAnalysis != nil` brings the check more in line with the post transform design and ensures that we can continue the same `opts.Edits` setup pattern we're using throughout these tests.
2. The `api.FetchRepository` call uses GraphQL, so we needed to register the GraphQL endpoint with our `httpStubs` in order to get the tests to work. Now you'll see that there is a test requiring the call to return `viewerCanAdminister: true` and a test requiring the call to return `viewerCanAdminister: false`, meaning we've successfully covered our permissions use-cases, here.

Hope this helps! I'm happy to answer any other questions about what's going on that you may have 🙂 